### PR TITLE
Don't drop empty hash literals from method calls

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -208,12 +208,14 @@ class Ruby2Ruby < SexpProcessor
     in_context :arglist do
       until exp.empty? do
         arg_type = exp.first.sexp_type
+        is_empty_hash = (exp.first == s(:hash))
         arg = process exp.shift
 
         next if arg.empty?
 
         strip_hash = (arg_type == :hash and
                       not BINARY.include? name and
+                      not is_empty_hash and
                       (exp.empty? or exp.first.sexp_type == :splat))
         wrap_arg = Ruby2Ruby::ASSIGN_NODES.include? arg_type
 

--- a/test/test_ruby2ruby.rb
+++ b/test/test_ruby2ruby.rb
@@ -346,6 +346,12 @@ class TestRuby2Ruby < R2RTestCase
     out = "begin\n  alpha\nrescue\n  beta\n  gamma\nend"
     util_compare inn, out
   end
+
+  def test_call_empty_hash
+    inn = s(:call, nil, :foo, s(:arglist, s(:hash)))
+    out = "foo({  })"
+    util_compare inn, out
+  end
   
   def util_compare sexp, expected_ruby, expected_eval = nil
     assert_equal expected_ruby, @processor.process(sexp)


### PR DESCRIPTION
Empty hash literals cannot safely be dropped from method calls.
For example,

   [1,2,3].reduce({}) { ... }

is NOT equivalent to

```
[1,2,3].reduce { ... }
```
