### PR TITLE
Remove not grobally used constants

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -3,22 +3,16 @@
 require 'rubygems'
 require 'sexp_processor'
 
-# REFACTOR: stolen from ruby_parser
 class Regexp
-  unless defined? ENC_NONE then
-    ENC_NONE = /x/n.options
-    ENC_EUC  = /x/e.options
-    ENC_SJIS = /x/s.options
-    ENC_UTF8 = /x/u.options
-
+  unless defined? CODES then
     CODES = {
-      EXTENDED   => 'x',
-      IGNORECASE => 'i',
-      MULTILINE  => 'm',
-      ENC_NONE   => 'n',
-      ENC_EUC    => 'e',
-      ENC_SJIS   => 's',
-      ENC_UTF8   => 'u',
+      EXTENDED     => 'x',
+      IGNORECASE   => 'i',
+      MULTILINE    => 'm',
+      /x/n.options => 'n',
+      /x/e.options => 'e',
+      /x/s.options => 's',
+      /x/u.options => 'u',
     }
   end
 end


### PR DESCRIPTION
Constants defined in Regexp collides with those in ruby_parser.
ruby_parser judges these constants are defined or not by ONCE constant, but ruby2ruby does not define it.
Therefore, ruby2ruby raises warning when used with the latest ruby_parser.
