### PR TITLE
Ruby parser version bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ Hoe.spec 'ruby2ruby' do
   self.rubyforge_name = 'seattlerb'
 
   dependency "sexp_processor", "~> 4.0"
-  dependency "ruby_parser",    "~> 3.0.0"
+  dependency "ruby_parser",    "~> 3.1.0"
 end
 
 def process ruby, file="stdin"


### PR DESCRIPTION
Some other gems currently can't update [ruby_parser](https://github.com/seattlerb/ruby_parser) due to conflicting dependencies.

e.g.  presidentbeef/brakeman#226
