### PR TITLE
Only convert single-expression methods to attrs

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -314,7 +314,7 @@ class Ruby2Ruby < SexpProcessor
     type1 = exp[1].first
     type2 = exp[2].first rescue nil
 
-    if type1 == :args and [:ivar, :iasgn, :attrset].include? type2 then
+    if type1 == :args and exp[3].nil? and [:ivar, :iasgn, :attrset].include? type2 then
       name = exp.first # don't shift in case we pass through
       case type2
       when :ivar then


### PR DESCRIPTION
Should fix issues in #15

and also this one:

``` ruby
def b
  @b
  @a
end
```

```
$ r2r_show test.rb
malloc_limit=50000000 (8000000)
heap_min_slots=500000 (10000)
/Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp.rb:173:in `find_node': multiple nodes for ivar were found in s(:b, s(:args), s(:ivar, :@b), s(:ivar, :@a)) (NoMethodError)
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp.rb:209:in `method_missing'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/ruby2ruby-2.0.4/lib/ruby2ruby.rb:322:in `process_defn'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp_processor.rb:218:in `block (2 levels) in process'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp_processor.rb:275:in `error_handler'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp_processor.rb:217:in `block in process'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp_processor.rb:340:in `in_context'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/sexp_processor-4.2.0/lib/sexp_processor.rb:194:in `process'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/ruby2ruby-2.0.4/bin/r2r_show:31:in `block in <top (required)>'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/ruby2ruby-2.0.4/bin/r2r_show:24:in `each'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/gems/ruby2ruby-2.0.4/bin/r2r_show:24:in `<top (required)>'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/bin/r2r_show:23:in `load'
    from /Users/collins/.rvm/gems/ruby-1.9.3-p392@WHATEVS/bin/r2r_show:23:in `<main>'
```
