### PR TITLE
Parenthesis around rescue statement modifiers

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -55,6 +55,7 @@ class Ruby2Ruby < SexpProcessor
                   :op_asgn_or,
                   :return,
                   :if, # HACK
+                  :rescue,
                  ]
 
   def initialize # :nodoc:
@@ -83,7 +84,10 @@ class Ruby2Ruby < SexpProcessor
   def process_arglist(exp) # custom made node # :nodoc:
     code = []
     until exp.empty? do
-      code << process(exp.shift)
+      arg = exp.shift
+      to_wrap = arg.first == :rescue
+      arg_code = process arg
+      code << (to_wrap ? "(#{arg_code})" : arg_code)
     end
     code.join ', '
   end

--- a/test/test_ruby2ruby.rb
+++ b/test/test_ruby2ruby.rb
@@ -429,6 +429,26 @@ class TestRuby2Ruby < R2RTestCase
     util_compare inn, out
   end
 
+  def test_array_adds_parens_around_rescue
+    inn = s(:array,
+            s(:call, nil, :a),
+            s(:rescue, s(:call, nil, :b), s(:resbody, s(:array), s(:call, nil, :c))))
+    out = "[a, (b rescue c)]"
+
+    util_compare inn, out
+  end
+  
+  def test_call_arglist_rescue
+    inn = s(:call,
+            nil,
+            :method,
+            s(:rescue,
+              s(:call, nil, :a),
+              s(:resbody, s(:array), s(:call, nil, :b))))
+    out = "method((a rescue b))"
+    util_compare inn, out
+  end
+
   def test_unless_vs_if_not
     rb1 = "a unless b"
     rb2 = "a if (not b)"


### PR DESCRIPTION
Hi,

MRI cannot parse [a rescue b], but can parse semantically equivalent [(a rescue b)]. For the following sexp:

``` ruby
s(:array,
 s(:rescue, s(:call, nil, :a), s(:resbody, s(:array), s(:call, nil, :b))))
```

Ruby2ruby returns `[a rescue b]` which is unparseable.

A similar issue can be recreated with method((a rescue b)) which is legal, but for the sexp

``` ruby
s(:call,
 nil,
 :method,
 s(:rescue, s(:lit, 1), s(:resbody, s(:array), s(:lit, 2))))
```

Ruby2Ruby outputs `method(a rescue b)` which is unparseable by MRI.

The fix will add parenthesis around rescue arguments. Two tests included.

Note that this suggested fix does not pass one test from `sexp_processor`. This one test is _wrong_ and I'll proceed to create a pull request that fixes the test
