### PR TITLE
Add warning that #process destroys its input

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,8 +27,9 @@ processors in ruby easier than ever!
     
     pp sexp
 
-    p ruby2ruby.process(sexp)
-    
+    p ruby2ruby.process(sexp.deep_clone) # Note: #process destroys its input, so
+                                         # #deep_clone if you need to preserve it
+
     ## outputs:
 
     s(:block,


### PR DESCRIPTION
The `#process` method works by progressively consuming the input sexp, so
if you need to preserve the input value for other purposes, it's
important to clone it.

The `#deep_clone` method is defined on `Object` in sexp_processor:

https://github.com/seattlerb/sexp_processor/blob/master/lib/sexp_processor.rb#L613

This addresses issue #27
