### PR TITLE
Wrap fewer hash values in parentheses

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -60,6 +60,24 @@ class Ruby2Ruby < SexpProcessor
                   :rescue,
                  ]
 
+  ##
+  # Some sexp types are OK without parens when appearing as hash values.
+  # This list can include `:call`s because they're always printed with parens
+  # around their arguments. For example:
+  #
+  #     { :foo => (bar("baz")) } # The outer parens are unnecessary
+  #     { :foo => bar("baz") } # This is the normal code style
+
+  HASH_VAL_NO_PAREN = [
+    :call,
+    :false,
+    :lit,
+    :lvar,
+    :nil,
+    :str,
+    :true
+  ]
+
   def initialize # :nodoc:
     super
     @indent = "  "
@@ -485,7 +503,7 @@ class Ruby2Ruby < SexpProcessor
       rhs = exp.shift
       t = rhs.first
       rhs = process rhs
-      rhs = "(#{rhs})" unless [:lit, :str].include? t # TODO: verify better!
+      rhs = "(#{rhs})" unless HASH_VAL_NO_PAREN.include? t
 
       result << "#{lhs} => #{rhs}"
     end

--- a/test/test_ruby2ruby.rb
+++ b/test/test_ruby2ruby.rb
@@ -80,6 +80,49 @@ class TestRuby2Ruby < R2RTestCase
     assert_equal exp, eval(out)
   end
 
+  def test_hash_parens_str
+    inn = s(:hash, s(:lit, :k), s(:str, "banana"))
+    out = '{ :k => "banana" }'
+    util_compare inn, out
+  end
+
+  def test_hash_parens_lit
+    inn = s(:hash, s(:lit, :k), s(:lit, 0.07))
+    out = "{ :k => 0.07 }"
+    util_compare inn, out
+  end
+
+  def test_hash_parens_bool
+    inn = s(:hash, s(:lit, :k), s(:true))
+    out = "{ :k => true }"
+    util_compare inn, out
+  end
+
+  def test_hash_parens_nil
+    inn = s(:hash, s(:lit, :k), s(:nil))
+    out = "{ :k => nil }"
+    util_compare inn, out
+  end
+
+  def test_hash_parens_lvar
+    inn = s(:hash, s(:lit, :k), s(:lvar, :x))
+    out = "{ :k => x }"
+    util_compare inn, out
+  end
+
+  def test_hash_parens_call
+    inn = s(:hash, s(:lit, :k), s(:call, nil, :foo, s(:lit, :bar)))
+    out = "{ :k => foo(:bar) }"
+    util_compare inn, out
+  end
+
+  def test_hash_parens_iter
+    iter = s(:iter, s(:call, nil, :foo), s(:args), s(:str, "bar"))
+    inn = s(:hash, s(:lit, :k), iter)
+    out = '{ :k => (foo { "bar" }) }'
+    util_compare inn, out
+  end
+
   def test_and_alias
     inn = s(:and, s(:true), s(:alias, s(:lit, :a), s(:lit, :b)))
     out = "true and (alias :a :b)"


### PR DESCRIPTION
No longer wraps the following:

- s(:true)
- s(:false)
- method calls with no arguments

Fixes https://github.com/seattlerb/ruby2ruby/issues/35