### PR TITLE
No longer simplify code into attr_reader/writer

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -390,20 +390,6 @@ class Ruby2Ruby < SexpProcessor
 
     body = s() if body == s(s(:nil)) # empty it out of a default nil expression
 
-    # s(:defn, name, args, ivar|iasgn)
-    case exp
-    when s{ s(:defn, atom, t(:args), s(:ivar, atom)) } then # TODO: atom -> _
-      _, ivar = body.first
-      ivar = ivar.to_s[1..-1] # remove leading @
-      reader = name.to_s
-      return "attr_reader #{name.inspect}" if reader == ivar
-    when s{ s(:defn, atom, t(:args), s(:iasgn, atom, s(:lvar, atom))) } then
-      _, ivar, _val = body.first
-      ivar = ivar.to_s[1..-1] # remove leading @
-      reader = name.to_s.chomp "="
-      return "attr_writer :#{reader}" if reader == ivar
-    end
-
     body = body.map { |ssexp|
       process ssexp
     }

--- a/test/test_ruby2ruby.rb
+++ b/test/test_ruby2ruby.rb
@@ -126,40 +126,6 @@ class TestRuby2Ruby < R2RTestCase
     assert_parse inn, out
   end
 
-  def test_attr_reader_diff
-    inn = s(:defn, :same, s(:args), s(:ivar, :@diff))
-    out = "def same\n  @diff\nend"
-    assert_parse inn, out
-  end
-
-  def test_attr_reader_same
-    do_not_check_sexp!
-
-    inn = s(:defn, :same, s(:args), s(:ivar, :@same))
-    out = "attr_reader :same"
-    assert_parse inn, out
-  end
-
-  def test_attr_reader_double
-    inn = s(:defn, :same, s(:args), s(:ivar, :@same), s(:ivar, :@diff))
-    out = "def same\n  @same\n  @diff\nend"
-    assert_parse inn, out
-  end
-
-  def test_attr_reader_same_name_diff_body
-    do_not_check_sexp!
-
-    inn = s(:defn, :same, s(:args), s(:not, s(:ivar, :@same)))
-    out = "def same\n  (not @same)\nend"
-    assert_parse inn, out
-  end
-
-  def test_attr_writer_diff
-    inn = s(:defn, :same=, s(:args, :o), s(:iasgn, :@diff, s(:lvar, :o)))
-    out = "def same=(o)\n  @diff = o\nend"
-    assert_parse inn, out
-  end
-
   def assert_str exp, src
     assert_equal s(:str, exp), RubyParser.new.process(src)
   end
@@ -257,27 +223,6 @@ class TestRuby2Ruby < R2RTestCase
 
     out = "return (if foo.baaaaaaar then\n  ::B.newsss(true)\nelse\n  ::B.newadsfasdfasdfasdfasdsssss(false)\nend)"
 
-    assert_parse inn, out
-  end
-
-  def test_attr_writer_double
-    inn = s(:defn, :same=, s(:args, :o),
-            s(:iasgn, :@same, s(:lvar, :o)), s(:iasgn, :@diff, s(:lvar, :o)))
-    out = "def same=(o)\n  @same = o\n  @diff = o\nend"
-    assert_parse inn, out
-  end
-
-  def test_attr_writer_same_name_diff_body
-    inn = s(:defn, :same=, s(:args, :o), s(:iasgn, :@same, s(:lit, 42)))
-    out = "def same=(o)\n  @same = 42\nend"
-    assert_parse inn, out
-  end
-
-  def test_attr_writer_same
-    do_not_check_sexp!
-
-    inn = s(:defn, :same=, s(:args, :o), s(:iasgn, :@same , s(:lvar, :o)))
-    out = "attr_writer :same"
     assert_parse inn, out
   end
 


### PR DESCRIPTION
This proposal removes support for converting code like
```
def x
  @x
end
```
into `attr_reader :x` (and similar for `attr_writer :x`).

In most contexts the expressions are equivalent, but not always. For example, if you feed the string to `instance_eval`, then
```
instance_eval "def x; @x; end"
```
executes just fine, while
```
parser = RubyParser.new
r2r = Ruby2Ruby.new
instance_eval r2r.process(parser.parse("def x; @x; end"))`
# i.e. instance_eval "attr_reader :x"
```
will fail with `NoMethodError: undefined method 'attr_reader' for main:Object`. 

An assumption behind this change is that RubyParser + Ruby2Ruby are intended to 'roundtrip' and result in code that is equivalent for all practical purposes.