### PR TITLE
Support Ruby 3.1 hash shorthand syntax

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -544,6 +544,13 @@ class Ruby2Ruby < SexpProcessor
     result = pairs.each_slice(2).map { |k, v|
       if k.sexp_type == :kwsplat then
         "%s" % process(k)
+      elsif v.nil?
+        # Shorthand hash syntax
+        unless k.sexp_type == :lit and k.value.is_a? Symbol
+          raise "Expected symbol for hash key, but got #{k.inspect}"
+        end
+
+        "#{k.value}:"
       else
         t = v.sexp_type
 

--- a/test/test_ruby2ruby.rb
+++ b/test/test_ruby2ruby.rb
@@ -118,6 +118,14 @@ class TestRuby2Ruby < R2RTestCase
     assert_parse inn, out
   end
 
+  def test_hash_shorthand_invalid_key_type
+    inn = s(:hash, s(:str, 'k'), nil)
+    out = '{ k: }'
+    assert_raises do
+      assert_parse inn, out
+    end
+  end
+
   def test_and_alias
     inn = s(:and, s(:true), s(:alias, s(:lit, :a), s(:lit, :b)))
     out = "true and (alias :a :b)"


### PR DESCRIPTION
like `{ x: }`

(I guess at this point ruby2ruby is pretty far behind on Ruby syntax...)