### PR TITLE
Fix pin operator incorrectly applied to variables in pattern match body

### DIFF
--- a/lib/ruby2ruby.rb
+++ b/lib/ruby2ruby.rb
@@ -609,7 +609,11 @@ class Ruby2Ruby < SexpProcessor
     _, lhs, *rhs = exp
 
     cond = process lhs
-    body = rhs.compact.map { |sexp| indent process sexp }
+    body = rhs.compact.map { |sexp|
+      in_context :in_body do
+        indent process sexp
+      end
+    }
 
     body << indent("# do nothing") if body.empty?
     body = body.join "\n"

--- a/test/test_ruby2ruby.rb
+++ b/test/test_ruby2ruby.rb
@@ -1002,6 +1002,16 @@ class TestRuby2Ruby < R2RTestCase
     assert_case_in "Object[b: 1]", s(:hash_pat, s(:const, :Object), s(:lit, :b), s(:lit, 1))
   end
 
+  def test_case_in_body_does_not_pin_variables
+    inn = s(:case, s(:call, nil, :x),
+            s(:in,
+              s(:array_pat, nil, s(:lasgn, :a), s(:lasgn, :b)),
+              s(:lvar, :a)),
+            nil)
+    out = "case x\nin [a, b] then\n  a\nend"
+    assert_parse inn, out
+  end
+
   def test_interpolation_and_escapes
     # log_entry = "  \e[#{message_color}m#{message}\e[0m   "
     inn = s(:lasgn, :log_entry,


### PR DESCRIPTION
Bug: process_in processes both the pattern and the body while the SexpProcessor context stack contains :in. The __var method checks context[1] for :in or /_pat$/ and prepends ^ (pin operator) to all lvar references. This causes local variables in the body (after "then") to be incorrectly rendered with ^, producing invalid Ruby.

For example, `case x; in [a, b]; a; end` was rendered as:
```ruby
  case x
  in [a, b] then
    ^a        # <-- wrong: ^ should only appear in patterns
  end
```
Fix: wrap body processing in `in_context :in_body` so that __var sees :in_body instead of :in on the context stack and skips the pin prefix. Pattern variables inside the pattern itself continue to be pinned correctly since the pattern is still processed in :in context.

Found during https://github.com/theforeman/safemode/pull/60. Seemed good enough to make a patch suggestion here, so please tell what do you think :)